### PR TITLE
speedup unique impressions

### DIFF
--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -48,11 +48,11 @@ module ImpressionistController
     end
     
     def unique_instance?(impressionable, unique_opts)
-      return unique_opts.blank? || impressionable.impressions.where(unique_query(unique_opts)).size == 0
+      return unique_opts.blank? || !impressionable.impressions.where(unique_query(unique_opts)).exists?
     end
     
     def unique?(unique_opts)
-      return unique_opts.blank? || Impression.where(unique_query(unique_opts)).size == 0
+      return unique_opts.blank? || !Impression.where(unique_query(unique_opts)).exists?
     end
     
     # creates the query to check for uniqueness


### PR DESCRIPTION
When using the :unique option, then a `impressions.count == 0`is used to validate uniqueness. This requires a full table scan every time (without appropriate indexes):

`SELECT COUNT(*) FROM `impressions``

 Using `!impressions.exists?` results in a much more efficient query (but even requires a full table scan when there is no existing impression):

`SELECT 1 FROM `impressions` LIMIT 1`
