### PR TITLE
Adds mongo_mapper ORM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+*.DS_Store
 /coverage
 /pkg
 /rdoc

--- a/app/models/impression.rb
+++ b/app/models/impression.rb
@@ -1,20 +1,3 @@
-class Impression < ActiveRecord::Base
+class Impression
   belongs_to :impressionable, :polymorphic=>true
-
-  after_save :update_impressions_counter_cache
-
-  attr_accessible :impressionable_type, :impressionable_id, :user_id,
-  :controller_name, :action_name, :view_name, :request_hash, :ip_address,
-  :session_hash, :message, :referrer
-
-  private
-
-  def update_impressions_counter_cache
-    impressionable_class = self.impressionable_type.constantize
-
-    if impressionable_class.counter_cache_options
-      resouce = impressionable_class.find(self.impressionable_id)
-      resouce.try(:update_counter_cache)
-    end
-  end
 end

--- a/app/models/impressionist/impressionable.rb
+++ b/app/models/impressionist/impressionable.rb
@@ -6,11 +6,6 @@ module Impressionist
       attr_accessor :cache_options
       @cache_options = nil
 
-      def is_impressionable(options={})
-        has_many :impressions, :as => :impressionable, :dependent => :destroy
-        @cache_options = options[:counter_cache]
-      end
-
       def counter_cache_options
         if @cache_options
           options = { :column_name => :impressions_count, :unique => false }

--- a/lib/generators/impressionist_generator.rb
+++ b/lib/generators/impressionist_generator.rb
@@ -2,6 +2,11 @@ module Impressionist
   module Generators
     class ImpressionistGenerator < Rails::Generators::Base
       hook_for :orm
+      source_root File.expand_path('../templates', __FILE__)
+
+      def copy_config_file
+        template 'impression.rb', 'config/initializers/impression.rb'
+      end
     end
   end
 end

--- a/lib/generators/mongo_mapper/impressionist_generator.rb
+++ b/lib/generators/mongo_mapper/impressionist_generator.rb
@@ -1,0 +1,8 @@
+module MongoMapper
+  module Generators
+    class ImpressionistGenerator < Rails::Generators::Base
+      # Empty for now, need it for generating the config file without
+      # triggering other ORM's generators.
+    end
+  end
+end

--- a/lib/generators/templates/impression.rb
+++ b/lib/generators/templates/impression.rb
@@ -1,0 +1,5 @@
+# Use this hook to configure impressionist parameters
+Impressionist.setup do |config|
+  # Define ORM. Could be :active_record (default) and :mongo_mapper
+  # config.orm = :active_record
+end

--- a/lib/impressionist.rb
+++ b/lib/impressionist.rb
@@ -1,4 +1,12 @@
 require "impressionist/engine.rb"
 
 module Impressionist
+  # Define ORM
+  mattr_accessor :orm
+  @@orm = :active_record
+
+  # Load configuration from initializer
+  def self.setup
+    yield self
+  end
 end

--- a/lib/impressionist/engine.rb
+++ b/lib/impressionist/engine.rb
@@ -3,8 +3,16 @@ require "rails"
 
 module Impressionist
   class Engine < Rails::Engine
-    initializer 'impressionist.extend_ar' do |app|
-      ActiveRecord::Base.send(:include, Impressionist::Impressionable)
+    initializer 'impressionist.model' do |app|
+      if Impressionist.orm == :active_record
+        require "impressionist/models/active_record/impression.rb"
+        require "impressionist/models/active_record/impressionist/impressionable.rb"
+        ActiveRecord::Base.send(:include, Impressionist::Impressionable)
+      elsif Impressionist.orm == :mongo_mapper
+        require "impressionist/models/mongo_mapper/impression.rb"
+        require "impressionist/models/mongo_mapper/impressionist/impressionable.rb"
+        MongoMapper::Document.plugin Impressionist::Impressionable
+      end
     end
 
     initializer 'impressionist.controller' do

--- a/lib/impressionist/models/active_record/impression.rb
+++ b/lib/impressionist/models/active_record/impression.rb
@@ -1,0 +1,18 @@
+class Impression < ActiveRecord::Base
+  attr_accessible :impressionable_type, :impressionable_id, :user_id,
+  :controller_name, :action_name, :view_name, :request_hash, :ip_address,
+  :session_hash, :message, :referrer
+
+  after_save :update_impressions_counter_cache
+
+  private
+
+  def update_impressions_counter_cache
+    impressionable_class = self.impressionable_type.constantize
+
+    if impressionable_class.counter_cache_options
+      resouce = impressionable_class.find(self.impressionable_id)
+      resouce.try(:update_counter_cache)
+    end
+  end
+end

--- a/lib/impressionist/models/active_record/impressionist/impressionable.rb
+++ b/lib/impressionist/models/active_record/impressionist/impressionable.rb
@@ -1,0 +1,12 @@
+module Impressionist
+  module Impressionable
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def is_impressionable(options={})
+        has_many :impressions, :as => :impressionable, :dependent => :destroy
+        @cache_options = options[:counter_cache]
+      end
+    end
+  end
+end

--- a/lib/impressionist/models/mongo_mapper/impression.rb
+++ b/lib/impressionist/models/mongo_mapper/impression.rb
@@ -1,0 +1,17 @@
+class Impression
+  include MongoMapper::Document
+
+  key :impressionable_type, String
+  key :impressionable_id, String
+  key :user_id, String
+  key :controller_name, String
+  key :action_name, String
+  key :view_name, String
+  key :request_hash, String
+  key :ip_address, String
+  key :session_hash, String
+  key :message, String
+  key :referrer, String
+
+  timestamps!
+end

--- a/lib/impressionist/models/mongo_mapper/impressionist/impressionable.rb
+++ b/lib/impressionist/models/mongo_mapper/impressionist/impressionable.rb
@@ -1,0 +1,12 @@
+module Impressionist
+  module Impressionable
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def is_impressionable(options={})
+        many :impressions, :as => :impressionable, :dependent => :destroy
+        @cache_options = options[:counter_cache]
+      end
+    end
+  end
+end

--- a/test_app/config/initializers/impression.rb
+++ b/test_app/config/initializers/impression.rb
@@ -1,0 +1,5 @@
+# Use this hook to configure impressionist parameters
+Impressionist.setup do |config|
+  # Define ORM. Could be :active_record (default) and :mongo_mapper
+  # config.orm = :active_record
+end


### PR DESCRIPTION
Hi,

This is a rather big commit, with no tests, which works in a local MongoMapper app. Previous commit tests are passing.

Here I move ORM specific code from app/models to lib/impressionist/:orm/models, so it's not tied only to AR, and I add an Impression MM model.

The flow for an AR installation is the same as before, except it now adds a config/initializers/impression.rb config file on install for if we want to override the ORM used (the option is commented out, :active_record by default).

Running `rails g impressionist --orm mongo_mapper` only installs that file, no migrations of course, and when you set the mongo_mapper ORM option, Impressions are saved as MM documents.

If you need more tests or any other thing for merging it, please tell.

Thanks for the library,

Tute.
