### PR TITLE
Requiring generic model code

### DIFF
--- a/lib/impressionist/engine.rb
+++ b/lib/impressionist/engine.rb
@@ -4,6 +4,7 @@ require "rails"
 module Impressionist
   class Engine < Rails::Engine
     initializer 'impressionist.model' do |app|
+      require "../app/models/impressionist/impressionable.rb"
       if Impressionist.orm == :active_record
         require "impressionist/models/active_record/impression.rb"
         require "impressionist/models/active_record/impressionist/impressionable.rb"

--- a/lib/impressionist/models/mongo_mapper/impression.rb
+++ b/lib/impressionist/models/mongo_mapper/impression.rb
@@ -12,6 +12,5 @@ class Impression
   key :session_hash, String
   key :message, String
   key :referrer, String
-
   timestamps!
 end

--- a/test_app/Gemfile
+++ b/test_app/Gemfile
@@ -11,6 +11,7 @@ platforms :jruby do
 end
 
 platforms :ruby, :mswin, :mingw do
+  gem 'pg'
   gem 'sqlite3'
 end
 

--- a/test_app/app/controllers/widgets_controller.rb
+++ b/test_app/app/controllers/widgets_controller.rb
@@ -9,5 +9,4 @@ class WidgetsController < ApplicationController
 
   def new
   end
-
 end


### PR DESCRIPTION
Requiring generic model code. Fixes:
- https://github.com/charlotte-ruby/impressionist/issues/32
- https://github.com/charlotte-ruby/impressionist/issues/33

It's weird that test_app/spec/models/counter_caching_spec.rb specs were not complaining about this.
