### PR TITLE
Optimize impressionist_count query via arel count with distinct option

### DIFF
--- a/app/models/impressionist/impressionable.rb
+++ b/app/models/impressionist/impressionable.rb
@@ -26,10 +26,7 @@ module Impressionist
     def impressionist_count(options={})
       options.reverse_merge!(:filter=>:request_hash, :start_date=>nil, :end_date=>Time.now)
       imps = options[:start_date].blank? ? impressions : impressions.where("created_at>=? and created_at<=?",options[:start_date],options[:end_date])
-      if options[:filter]!=:all
-        imps = imps.select(options[:filter]).group(options[:filter])
-      end
-      imps.all.size
+      options[:filter] == :all ? imps.count : imps.count(options[:filter], :distinct => true)
     end
 
     def update_counter_cache

--- a/test_app/spec/models/counter_caching_spec.rb
+++ b/test_app/spec/models/counter_caching_spec.rb
@@ -21,7 +21,7 @@ describe Impression do
   describe "#update_counter_cache" do
     it "should update the counter cache column to reflect the correct number of impressions" do
       lambda {
-         Impression.create(:impressionable_type => @widget.class.name, :impressionable_id => @widget.id)
+         @widget.impressions.create(:request_hash => 'abcd1234')
          @widget.reload
        }.should change(@widget, :impressions_count).from(0).to(1)
     end


### PR DESCRIPTION
I don't want to load impressions in memory to obtain the count, so I'm suggesting use of the :distinct option with a call to arel count instead. It omits items from the count when the value is nil (which I believe is a desired outcome), so I set the request_hash in the counter cache test.
