### PR TITLE
Avoid updating updated_at when counter_cache column is updated.

### DIFF
--- a/app/models/impressionist/impressionable.rb
+++ b/app/models/impressionist/impressionable.rb
@@ -38,7 +38,8 @@ module Impressionist
       cache_options = self.class.impressionist_counter_cache_options
       column_name = cache_options[:column_name].to_sym
       count = cache_options[:unique] ? impressionist_count(:filter => :ip_address) : impressionist_count
-      update_attribute(column_name, count)
+      old_count = send(column_name) || 0
+      self.class.update_counters(id, column_name => (count - old_count))
     end
 
     # OLD METHODS - DEPRECATE IN V0.5

--- a/test_app/spec/models/counter_caching_spec.rb
+++ b/test_app/spec/models/counter_caching_spec.rb
@@ -38,6 +38,13 @@ describe Impression do
          @widget.reload
        }.should change(@widget, :impressions_count).from(0).to(1)
     end
+
+    it "should not update the timestamp on the impressable" do
+      lambda {
+         @widget.impressions.create(:request_hash => 'abcd1234')
+         @widget.reload
+       }.should_not change(@widget, :updated_at)
+    end
   end
 
 end


### PR DESCRIPTION
Updating the counter_cache should not update the updated_at timestamp. This will cause creation of child records to make parent records seem updated, when they are actually not.
