### PR TITLE
Use a real polymorphic relationship

### DIFF
--- a/lib/impressionist/models/active_record/impression.rb
+++ b/lib/impressionist/models/active_record/impression.rb
@@ -2,7 +2,7 @@ class Impression < ActiveRecord::Base
   attr_accessible :impressionable_type, :impressionable_id, :user_id,
   :controller_name, :action_name, :view_name, :request_hash, :ip_address,
   :session_hash, :message, :referrer
-
+  belongs_to :impressionable, :polymorphic => true
   after_save :update_impressions_counter_cache
 
   private


### PR DESCRIPTION
We wanted to find the object the Impression was related to. Is there a reason your code goes through such gymnastics to do this rather than use a proper relationship?
