### PR TITLE
Remove message index

### DIFF
--- a/upgrade_migrations/version_1_1_2.rb
+++ b/upgrade_migrations/version_1_1_2.rb
@@ -1,9 +1,0 @@
-class Version04UpdateImpressionsTable < ActiveRecord::Migration
-  def self.up
-    add_index :impressions, [:impressionable_type, :message, :impressionable_id], :name => "impressionable_type_message_index", :unique => false
-  end
-
-  def self.down
-    remove_index :impressions, :impressionable_type_message_index
-  end
-end


### PR DESCRIPTION
I confirmed the tests passed locally. Seems better to just outright remove the upgrade_migration than write a new one that undoes this change since people were seeing errors in MySQL when trying to run the existing migration.
