### PR TITLE
Fix uniqueness of impressionable_type

### DIFF
--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -78,7 +78,7 @@ module ImpressionistController
     # creates a statment hash that contains default values for creating an impression.
     def direct_create_statement(query_params={})
       query_params.reverse_merge!(
-        :impressionable_type => controller_name.singularize.camelize,
+        :impressionable_type => controller_path.singularize.camelize,
         :impressionable_id=> params[:id]
         )
       associative_create_statement(query_params)


### PR DESCRIPTION
Changed generating impressionable_type by from controller_name to controller_path for namespaced controllers.

For Foo::Bar controller, when we impressionist(@foo_bar, nil, unique: [:impressionable_type, :impressionable_id, :user_id] then actual SQL statement is

SELECT 1 AS one FROM "impressions" WHERE "impressions"."impressionable_id" = 1 AND "impressions"."impressionable_type" = 'Foo::Bar' AND (("impressions"."impressionable_type" = 'Bar' AND "impressions"."impressionable_id" = 1 AND "impressions"."user_id" = 1)) LIMIT 1

So impressions_count is always increasing, but it is not we supposed to.
