### PR TITLE
Hstore support

### DIFF
--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -64,7 +64,7 @@ module ImpressionistController
 
     # creates a statment hash that contains default values for creating an impression via an AR relation.
     def associative_create_statement(query_params={})
-      query_params = query_params.reverse_merge!(
+      query_params = query_params.merge!(
         :controller_name => controller_name,
         :action_name => action_name,
         :user_id => user_id,
@@ -73,7 +73,7 @@ module ImpressionistController
         :ip_address => request.remote_ip,
         :referrer => request.referer
       )
-      query_params.reverse_merge!(:params => params) if Impression.hstore_enabled?
+      query_params.merge!(:params => params) if Impression.hstore_enabled?
       query_params
     end
 

--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -64,7 +64,7 @@ module ImpressionistController
 
     # creates a statment hash that contains default values for creating an impression via an AR relation.
     def associative_create_statement(query_params={})
-      query_params.reverse_merge!(
+      query_params = query_params.reverse_merge!(
         :controller_name => controller_name,
         :action_name => action_name,
         :user_id => user_id,
@@ -72,7 +72,9 @@ module ImpressionistController
         :session_hash => session_hash,
         :ip_address => request.remote_ip,
         :referrer => request.referer
-        )
+      )
+      query_params.reverse_merge!(:params => params) if Impression.hstore_enabled?
+      query_params
     end
 
     # creates a statment hash that contains default values for creating an impression.

--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -73,7 +73,7 @@ module ImpressionistController
         :ip_address => request.remote_ip,
         :referrer => request.referer
       )
-      query_params.merge!(:params => params) if Impression.hstore_enabled?
+      query_params.merge!(:params => params) if !!(Impressionist.hstore)
       query_params
     end
 

--- a/lib/generators/active_record/impressionist_generator.rb
+++ b/lib/generators/active_record/impressionist_generator.rb
@@ -16,6 +16,26 @@ module ActiveRecord
       def create_migration_file
         migration_template 'create_impressions_table.rb', 'db/migrate/create_impressions_table.rb'
       end
+
+      def create_hstore_migration_file
+        if gem_available?('pg')
+          if yes?("Would you like to add activerecord-postgres-hstore support?")
+            gem("activerecord-postgres-hstore")
+            generate("hstore:setup")
+            migration_template 'add_params_to_impressions_table.rb', 'db/migrate/add_params_to_impressions_table.rb'
+          end
+        end
+      end
+
+      private
+
+      def gem_available?(name)
+         Gem::Specification.find_by_name(name)
+      rescue Gem::LoadError
+         false
+      rescue
+         Gem.available?(name)
+      end
     end
   end
 end

--- a/lib/generators/active_record/templates/add_params_to_impressions_table.rb
+++ b/lib/generators/active_record/templates/add_params_to_impressions_table.rb
@@ -1,0 +1,5 @@
+class AddParamsToImpressionsTable < ActiveRecord::Migration
+  def change
+    add_column :impressions, :params, :hstore
+  end
+end

--- a/lib/generators/templates/impression.rb
+++ b/lib/generators/templates/impression.rb
@@ -2,4 +2,6 @@
 Impressionist.setup do |config|
   # Define ORM. Could be :active_record (default), :mongo_mapper or :mongoid
   # config.orm = :active_record
+  # Define hstore support. Could be true or false
+  # config.hstore = false
 end

--- a/lib/impressionist.rb
+++ b/lib/impressionist.rb
@@ -2,8 +2,9 @@ require "impressionist/engine.rb"
 
 module Impressionist
   # Define ORM
-  mattr_accessor :orm
+  mattr_accessor :orm, :hstore
   @@orm = :active_record
+  @@hstore = false
 
   # Load configuration from initializer
   def self.setup

--- a/lib/impressionist/engine.rb
+++ b/lib/impressionist/engine.rb
@@ -18,6 +18,17 @@ module Impressionist
         require 'impressionist/models/mongoid/impressionist/impressionable.rb'
         Mongoid::Document.send(:include, Impressionist::Impressionable)
       end
+
+      Impression.class_eval do
+        if !!(Impressionist.hstore)
+          serialize :params, ActiveRecord::Coders::Hstore
+          scope :with, lambda {|key, value=nil|
+            where("params"+(value.nil? ? " ? '"+key+"'" : " @> '"+key+" => "+value+"'")) if self.hstore_enabled?
+          }
+        else
+          attr_accessor :params
+        end
+      end
     end
 
     initializer 'impressionist.controller' do

--- a/lib/impressionist/models/active_record/impression.rb
+++ b/lib/impressionist/models/active_record/impression.rb
@@ -2,16 +2,6 @@ class Impression < ActiveRecord::Base
   attr_accessible :impressionable_type, :impressionable_id, :user_id,
   :controller_name, :action_name, :view_name, :request_hash, :ip_address,
   :session_hash, :message, :referrer, :params
-  def self.hstore_enabled?
-    !!(ActiveRecord::Base.connection.table_exists?(:impressions) && ActiveRecord::Base.connection.column_exists?(:impressions, :params, :hstore))
-  end
-
-  serialize :params, ActiveRecord::Coders::Hstore if self.hstore_enabled?
-  attr_accessor :params unless self.hstore_enabled?
-
-  scope :with, lambda {|key, value=nil|
-    where("params"+(value.nil? ? " ? '"+key+"'" : " @> '"+key+" => "+value+"'")) if self.hstore_enabled?
-  }
 
   belongs_to :impressionable, :polymorphic=>true
 

--- a/lib/impressionist/models/active_record/impression.rb
+++ b/lib/impressionist/models/active_record/impression.rb
@@ -1,7 +1,17 @@
 class Impression < ActiveRecord::Base
   attr_accessible :impressionable_type, :impressionable_id, :user_id,
   :controller_name, :action_name, :view_name, :request_hash, :ip_address,
-  :session_hash, :message, :referrer
+  :session_hash, :message, :referrer, :params
+
+  def self.hstore_enabled?
+    ActiveRecord::Base.connection.table_exists?(:impressions) && ActiveRecord::Base.connection.column_exists?(:impressions, :params, :hstore)
+  end
+
+  serialize :params, ActiveRecord::Coders::Hstore if self.hstore_enabled?
+
+  scope :with, lambda {|key, value=nil|
+    where("params"+(value.nil? ? " ? '"+key+"'" : " @> '"+key+" => "+value+"'")) if self.hstore_enabled?
+  }
 
   belongs_to :impressionable, :polymorphic=>true
 

--- a/lib/impressionist/models/active_record/impression.rb
+++ b/lib/impressionist/models/active_record/impression.rb
@@ -2,12 +2,12 @@ class Impression < ActiveRecord::Base
   attr_accessible :impressionable_type, :impressionable_id, :user_id,
   :controller_name, :action_name, :view_name, :request_hash, :ip_address,
   :session_hash, :message, :referrer, :params
-
   def self.hstore_enabled?
-    ActiveRecord::Base.connection.table_exists?(:impressions) && ActiveRecord::Base.connection.column_exists?(:impressions, :params, :hstore)
+    !!(ActiveRecord::Base.connection.table_exists?(:impressions) && ActiveRecord::Base.connection.column_exists?(:impressions, :params, :hstore))
   end
 
   serialize :params, ActiveRecord::Coders::Hstore if self.hstore_enabled?
+  attr_accessor :params unless self.hstore_enabled?
 
   scope :with, lambda {|key, value=nil|
     where("params"+(value.nil? ? " ? '"+key+"'" : " @> '"+key+" => "+value+"'")) if self.hstore_enabled?

--- a/test_app/spec/controllers/controller_spec.rb
+++ b/test_app/spec/controllers/controller_spec.rb
@@ -119,10 +119,9 @@ describe WidgetsController do
       get "index"
       Impression.all.size.should eq 14
     end
-
   end
-
 end
+
 describe DummyController do
   fixtures :impressions
   render_views
@@ -130,5 +129,21 @@ describe DummyController do
   it "should log impression at the per action level on non-restful controller" do
     get "index"
     Impression.all.size.should eq 12
+  end
+
+  describe "hstore support" do
+
+    # Stub hstore methods for testing with sqlite
+    before(:each){
+      Impression.stub!(:hstore_enabled?).and_return(true)
+      Impression.any_instance.stub(:params=> {"controller"=>"dummy", "action"=>"index"})
+      Impression.stub_chain(:with).and_return(@impressions = [Impression.where(controller: 'widget')])
+    }
+
+    it "should log params when hstore_enabled?" do
+      get "index"
+      Impression.all.size.should eq 12
+      Impression.last.params.should eq({"controller"=>"dummy", "action"=>"index"})
+    end
   end
 end

--- a/test_app/spec/models/hstore_spec.rb
+++ b/test_app/spec/models/hstore_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Impression do
+  fixtures :articles,:impressions,:posts, :widgets
+
+  describe "hstore support" do
+
+    # Stub hstore methods for testing with sqlite
+    before(:each){
+      Impression.stub!(:hstore_enabled?).and_return(true)
+      Impression.any_instance.stub(:params=> {"controller"=>"dummy", "action"=>"index"})
+      Impression.stub_chain(:with).and_return(@impressions = [Impression.where(controller: 'widget')])
+    }
+
+    it "should respond true to hstore_enabled?" do
+      Impression.hstore_enabled?.should be_true
+    end
+
+    describe "'with' scope" do
+
+      it "should respond" do
+        Impression.should respond_to(:with)
+        Impression.should_receive(:with).and_return(Impression.with)
+      end
+
+      it "should respond with params key" do
+        Impression.with("controller").should_not be_empty
+      end
+
+      it "should respond with params key and value" do
+        Impression.with("controller", "widget").should_not be_empty
+      end
+    end
+
+    describe "instance" do
+
+      before(:each) do
+        @article = Article.find(1)
+      end
+
+      it "should respond to 'param' and return params hash" do
+        @article.impressions.create
+        @article.impressions.last.should respond_to(:params)
+        @article.impressions.last.params.should eq({"controller"=>"dummy", "action"=>"index"})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added Postgres hstore support.  Detects the pg gem in the gemfile on 'rails g impressionist' and asks the user if they want hstore support.  If so, it will add the hstore gem, run hstore:setup and create a migration to add a 'params' hstore column and index. It will then serialize all request params to the params column.  An Impression scope, Impression.with(key, value), enables searching for impressions by the params hash, by either key or key/value.
