### PR TITLE
Travis allow failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 1.9.3
   - ruby-head
 
-matrx:
+matrix:
   allow_failures:
     rvm:
       - rbx-18mode


### PR DESCRIPTION
Travis is failing due to Capybara requiring ruby >= 1.9.3.
