### PR TITLE
The gem spec fails because it does not recognize file path 

### DIFF
--- a/impressionist.gemspec
+++ b/impressionist.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path('../lib', __FILE__)
+$:.push File.expand_path("../lib", __FILE__)
 require 'impressionist/version'
 
 Gem::Specification.new do |s|
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.authors       = ['johnmcaliley']
 
   s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {spec,test_app/spec}/*`.split('\n')
+  s.test_files    = `git ls-files -- {spec,test_app/spec}/*`.split("\n")
   s.require_path  = ["lib"]
   s.required_rubygems_version = Gem::Requirement.new('>= 1.3.6') if s.respond_to? :required_rubygems_version=
 


### PR DESCRIPTION
Changed file paths from single quotes to double quotes so that split reads it like a single multi-line string instead of a multi-string array.
