### PR TITLE
Make associative_create_statement protected rather than private

### DIFF
--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -38,6 +38,21 @@ module ImpressionistController
       end
     end
 
+    protected
+
+    # creates a statment hash that contains default values for creating an impression via an AR relation.
+    def associative_create_statement(query_params={})
+      query_params.reverse_merge!(
+        :controller_name => controller_name,
+        :action_name => action_name,
+        :user_id => user_id,
+        :request_hash => @impressionist_hash,
+        :session_hash => session_hash,
+        :ip_address => request.remote_ip,
+        :referrer => request.referer
+        )
+    end
+
     private
 
     def bypass
@@ -60,19 +75,6 @@ module ImpressionistController
         query[param] = full_statement[param]
         query
       end
-    end
-
-    # creates a statment hash that contains default values for creating an impression via an AR relation.
-    def associative_create_statement(query_params={})
-      query_params.reverse_merge!(
-        :controller_name => controller_name,
-        :action_name => action_name,
-        :user_id => user_id,
-        :request_hash => @impressionist_hash,
-        :session_hash => session_hash,
-        :ip_address => request.remote_ip,
-        :referrer => request.referer
-        )
     end
 
     # creates a statment hash that contains default values for creating an impression.


### PR DESCRIPTION
Make associative_create_statement protected rather than private, so it can be accessed by subclasses.  This makes it easy for subclasses to add custom fields to the impression.

The use case I'm solving is when a controller needs to add a custom attribute to the impression when it's created.  To do this now I need to cut and paste the whole of the method, and then make my changes.  By making this method protected I can simply reference super and add the fields I require in my overridden method.

Not really much to test here, so there are no new specs.  But all existing specs pass.
