### PR TITLE
Don't include attr_accessible if StrongParameters is in use.

### DIFF
--- a/lib/impressionist/rails_toggle.rb
+++ b/lib/impressionist/rails_toggle.rb
@@ -1,20 +1,24 @@
 module Impressionist
-  # Responsability
+  # Responsibility
   # Toggles between rails > 3.1 < 4
   # In order to make attr_accessible available in a rails app < 4
 
   class RailsToggle
     # decides where or not to include attr_accessible
     def should_include?
-      ask_rails || false
+      supported_by_rails? && (not using_strong_parameters?)
     end
 
     private
 
+      def using_strong_parameters?
+        defined?(StrongParameters)
+      end
+
       # returns false if rails >= 4
       # true if rails < 4
-      def ask_rails
-        ::Rails::VERSION::MAJOR.to_i >= 4 ? false : true
+      def supported_by_rails?
+        ::Rails::VERSION::MAJOR.to_i < 4
       end
 
   end

--- a/tests/spec/rails_toggle_spec.rb
+++ b/tests/spec/rails_toggle_spec.rb
@@ -15,12 +15,24 @@ module Impressionist
 
       # see your_minitest_path/lib/minitest/mock.rb
       it "must not include attr_accessible" do
-        @toggle.stub :ask_rails, false do
+        @toggle.stub :supported_by_rails?, false do
           refute @toggle.should_include?
         end
       end
 
     end
 
+    describe "Strong Parameters" do
+
+      # see your_minitest_path/lib/minitest/mock.rb
+      it "must not include attr_accessible" do
+        @toggle.stub :supported_by_rails?, true do
+          @toggle.stub :using_strong_parameters?, true do
+            refute @toggle.should_include?
+          end
+        end
+      end
+
+    end
   end
 end


### PR DESCRIPTION
This change addresses Rails 3.x applications that are using the strong parameters gem.  For those apps we want to avoid including the attr_accessible statements.

Added a new spec to cover this case.  Everything is green.
