### PR TITLE
Travis Ci Update - Rails 4, Ruby 2.0, JRuby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@
 /test_app/test
 /test_app/vendor
 Gemfile.lock
+gemfiles/*.lock
 *.swo
 *.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,21 @@
 language: ruby
-
-bundler_args: '--binstubs --without documentation'
-before_install: gem install bundler
-
-before_script: "cd tests/test_app && bundle install && ./script/rails generate impressionist -f && rake db:migrate && cd .."
-
+before_script: 
+  - cd tests/test_app
+  - bundle exec rails g impressionist -f
+  - bundle exec rake db:migrate
+  - cd ..
 rvm:
-  - rbx-18mode
-  - rbx-19mode
-  - 1.8.7
   - 1.9.2
   - 1.9.3
-  - ruby-head
-
+  - 2.0.0
+  - jruby-19mode
+  - rbx-19mode
+gemfile:
+  - gemfiles/rails32.gemfile
+  - gemfiles/rails40.gemfile
 matrix:
+  exclude:
+    - rvm: 1.9.2
+      gemfile: gemfiles/rails40.gemfile
   allow_failures:
-      - rvm: rbx-18mode
-      - rvm: 1.8.7
       - rvm: 1.9.2
-      - rvm: ruby-head

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 3.2.12'
+gem 'jquery-rails'
+gem 'json'
+
+gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
+gem 'jdbc-sqlite3', :platforms => [:jruby]
+
+gem 'sqlite3', :platforms => [:ruby, :mswin, :mingw]
+
+gemspec :path => '../'

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 4.0.0'
+gem 'jquery-rails'
+gem 'json'
+
+gem 'activerecord-jdbcsqlite3-adapter', '1.3.0.rc1', :platforms => [:jruby]
+
+gem 'sqlite3', :platforms => [:ruby, :mswin, :mingw]
+
+gemspec :path => '../'

--- a/impressionist.gemspec
+++ b/impressionist.gemspec
@@ -20,13 +20,11 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'httpclient', '~> 2.2'
 
-  # Nokogiri has dropped support for Ruby 1.8.7 onwards version 1.5.10
-  s.add_dependency 'nokogiri', (RUBY_VERSION.match("1.8.7") ? '1.5.10' : '~> 1.6.0')
+  s.add_dependency 'nokogiri', '~> 1.6.0'
 
-  # Capybara has dropped support for Ruby 1.8.7 onwards version 2.0.3
   s.add_development_dependency 'capybara', '>= 2.0.3'
   s.add_development_dependency 'rake', '>= 0.9'
-  s.add_development_dependency 'rails', '3.2.12'
+  s.add_development_dependency 'rails', '>= 3.2.12', '< 4.1'
   s.add_development_dependency 'rdoc', '>= 2.4.2'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
This PR includes a number of changes to the Travis CI configuration, and some related changes to the gemspec.  Specifically:
1. Added Rails 4 as a permitted development dependency
2. Removed Ruby 1.8.7 as an allowed option from the gemspec
3. Removed Ruby 1.8.7, Rbx 1.8, and Ruby head from the Travis CI configuration (all specs were failing because of dependencies)
4. Created dedicated gemfiles for Rails 3.2.x and 4.0.x for use by Travis
5. Added Rails 4 to the test matrix
6. Added Ruby 2.0 and JRuby to the Travis CI configuration

The goal of this PR is to build confidence for use of this gem in both Rails 3.2.x and Rails 4.0.x apps, by ensuring the test matrix runs against both as part of CI.

All specs run green.
