### PR TITLE
Fix Mongoid undefined 'filter' error

### DIFF
--- a/lib/impressionist/models/mongoid/impressionist/impressionable.rb
+++ b/lib/impressionist/models/mongoid/impressionist/impressionable.rb
@@ -18,7 +18,7 @@ module Impressionist
 
       # Count all distinct impressions unless the :all filter is provided
       distinct = options[:filter] != :all
-      distinct ? imps.where(filter.ne => nil).distinct(filter).count : imps.count
+      distinct ? imps.where(options[:filter].ne => nil).distinct(options[:filter]).count : imps.count
     end
 
   end


### PR DESCRIPTION
Hi,

I found an error when using the `impressionist_count` method on mongoid models.

```
NameError: undefined local variable or method `filter'
```

Here is a small fix that seems to work, at least for my current project.

Have a nice day
