### PR TITLE
Issue for mongoid

### DIFF
--- a/lib/impressionist/models/mongoid/impression.rb
+++ b/lib/impressionist/models/mongoid/impression.rb
@@ -8,7 +8,7 @@ class Impression
   include Impressionist::CounterCache
   Impressionist::SetupAssociation.new(self).set
 
-  field :impressionable_id
+  field :impressionable_id, type: BSON::ObjectId
   field :impressionable_type
   field :user_id
   field :controller_name


### PR DESCRIPTION
Queries is always on ObjectId type of imperssion_id, while model not restricts the type.
Thats can cause to saves in String format, hence not imperssions will be counted on counter_cache
