### PR TITLE
change impressionable_id type to string

### DIFF
--- a/lib/generators/active_record/templates/create_impressions_table.rb
+++ b/lib/generators/active_record/templates/create_impressions_table.rb
@@ -2,7 +2,7 @@ class CreateImpressionsTable < ActiveRecord::Migration
   def self.up
     create_table :impressions, :force => true do |t|
       t.string :impressionable_type
-      t.integer :impressionable_id
+      t.string :impressionable_id
       t.integer :user_id
       t.string :controller_name
       t.string :action_name


### PR DESCRIPTION
I think it should use string type.
In case, I define to_param on model
and /posts/this-is-my-permalink will result in 0 value saved in column.
It work well in any case if use string type.
