### PR TITLE
Unique scope for impressionable instance overwritten unintentionally

### DIFF
--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -77,7 +77,7 @@ module ImpressionistController
     end
 
     def unique_instance?(impressionable, unique_opts)
-      return unique_opts.blank? || !impressionable.impressions.where(unique_query(unique_opts)).exists?
+      return unique_opts.blank? || !impressionable.impressions.where(unique_query(unique_opts).reject { |k,_| %w(impressionable_id impressionable_type).include?(k.to_s) }).exists?
     end
 
     def unique?(unique_opts)

--- a/tests/test_app/spec/controllers/impressionist_uniqueness_spec.rb
+++ b/tests/test_app/spec/controllers/impressionist_uniqueness_spec.rb
@@ -227,6 +227,14 @@ describe DummyController do
       Impression.should have(@impression_count + 1).records
     end
 
+    it "should recognize unique impressionable for a session" do
+      controller.stub(:session_hash).and_return(request.session_options[:id])
+      impressionable = Post.create
+      controller.impressionist(impressionable, nil, :unique => [:impressionable_id, :impressionable_type, :session_hash])
+      controller.impressionist(impressionable, nil, :unique => [:impressionable_id, :impressionable_type, :session_hash])
+      Impression.should have(@impression_count + 1).records
+    end
+
     it "should recognize different session" do
       impressionable = Post.create
       controller.stub(:session_hash).and_return("foo")


### PR DESCRIPTION
This is a fix for #134 where the unique conditions were unintentionally overwritten when the query was built.

The altered line is definitely a little portly and could go on a diet. However, I avoided trying to attempt to do any overhaul requiring tracking of the impressionable instance as a property to make the reference to `params[:id]` in `direct_create_statement` smarter.

:white_check_mark: Tests included and pass.
