### PR TITLE
fix  counter cache field doesn't updated #158

### DIFF
--- a/app/models/impressionist/impressionable.rb
+++ b/app/models/impressionist/impressionable.rb
@@ -8,7 +8,7 @@ module Impressionist
       DEFAULT_CACHE ||= {
         :counter_cache => false,
         :column_name => :impressions_count,
-        :unique => false
+        :unique => :all
       }
 
       def impressionist_counter_cache_options


### PR DESCRIPTION
the problem is caused by default value of cache_options[:unique] is false even when it is not passed.  #158   
