### PR TITLE
Unique impressionist of a instance which is using friendly_id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'rspec-rails'
   gem 'simplecov'
   gem 'systemu'
-  gem 'friendly_id', '~> 4.0.9'
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :test do
   gem 'rspec-rails'
   gem 'simplecov'
   gem 'systemu'
-  gem 'friendly_id', '~> 4.0.10.1'
+  gem 'friendly_id', '~> 4.0.9'
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :test do
   gem 'rspec-rails'
   gem 'simplecov'
   gem 'systemu'
+  gem 'friendly_id', '~> 4.0.10.1'
 end
 
 gemspec

--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -77,7 +77,7 @@ module ImpressionistController
     end
 
     def unique_instance?(impressionable, unique_opts)
-      return unique_opts.blank? || !impressionable.impressions.where(unique_query(unique_opts)).exists?
+      return unique_opts.blank? || !impressionable.impressions.where(unique_query(unique_opts, impressionable)).exists?
     end
 
     def unique?(unique_opts)
@@ -85,8 +85,8 @@ module ImpressionistController
     end
 
     # creates the query to check for uniqueness
-    def unique_query(unique_opts)
-      full_statement = direct_create_statement
+    def unique_query(unique_opts,impressionable=nil)
+      full_statement = direct_create_statement({},impressionable)
       # reduce the full statement to the params we need for the specified unique options
       unique_opts.reduce({}) do |query, param|
         query[param] = full_statement[param]
@@ -95,10 +95,10 @@ module ImpressionistController
     end
 
     # creates a statment hash that contains default values for creating an impression.
-    def direct_create_statement(query_params={})
+    def direct_create_statement(query_params={},impressionable=nil)
       query_params.reverse_merge!(
         :impressionable_type => controller_name.singularize.camelize,
-        :impressionable_id=> params[:id]
+        :impressionable_id => impressionable.present? ? impressionable.id : params[:id]
         )
       associative_create_statement(query_params)
     end

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -18,9 +18,10 @@ group :test do
   gem 'minitest'
   gem 'minitest-rails'
   gem 'rails', '~> 3.2.15'
-  gem 'rspec-rails'
+  gem 'rspec-rails', '~> 2.14.0'
   gem 'simplecov'
   gem 'systemu'
+  gem 'friendly_id', '~> 4.0.9'
 end
 
 gemspec :path => '../'

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -18,9 +18,10 @@ group :test do
   gem 'minitest'
   gem 'minitest-rails'
   gem 'rails', '~> 4.0.1'
-  gem 'rspec-rails'
+  gem 'rspec-rails', '~> 2.14.0'
   gem 'simplecov'
   gem 'systemu'
+  gem 'friendly_id', '~> 5.1.0'
 end
 
 gemspec :path => '../'

--- a/tests/test_app/.gitignore
+++ b/tests/test_app/.gitignore
@@ -15,3 +15,4 @@
 /coverage
 /log/*.log
 /tmp
+/.idea

--- a/tests/test_app/Gemfile
+++ b/tests/test_app/Gemfile
@@ -45,4 +45,4 @@ group :test do
 end
 
 gem 'jquery-rails'
-gem 'friendly_id', '~> 4.0.10.1'
+gem 'friendly_id', '~> 4.0.9'

--- a/tests/test_app/Gemfile
+++ b/tests/test_app/Gemfile
@@ -34,7 +34,7 @@ end
 
 group :development, :test do
   gem 'autotest-notification'
-  gem 'rspec-rails'
+  gem 'rspec-rails', '~> 2.14.0'
   gem 'spork'
 end
 
@@ -45,3 +45,4 @@ group :test do
 end
 
 gem 'jquery-rails'
+gem 'friendly_id', '~> 4.0.10.1'

--- a/tests/test_app/app/controllers/profiles_controller.rb
+++ b/tests/test_app/app/controllers/profiles_controller.rb
@@ -2,8 +2,6 @@ class ProfilesController < ApplicationController
   helper_method :current_user
 
   def show
-    @profile = Profile.friendly.find params[:id]
-    impressionist(@profile, nil, :unique => [:impressionable_type, :impressionable_id])
   end
 
   def current_user

--- a/tests/test_app/app/controllers/profiles_controller.rb
+++ b/tests/test_app/app/controllers/profiles_controller.rb
@@ -1,0 +1,16 @@
+class ProfilesController < ApplicationController
+  helper_method :current_user
+
+  def show
+    @profile = Profile.friendly.find params[:id]
+    impressionist(@profile, nil, :unique => [:impressionable_type, :impressionable_id])
+  end
+
+  def current_user
+    if session[:user_id]
+      user = User.new
+      user.id = session[:user_id]
+      @current_user ||= user
+    end
+  end
+end

--- a/tests/test_app/app/models/profile.rb
+++ b/tests/test_app/app/models/profile.rb
@@ -1,0 +1,6 @@
+class Profile < ActiveRecord::Base
+  extend FriendlyId
+
+  friendly_id :username, use: :slugged
+  is_impressionable
+end

--- a/tests/test_app/app/views/profiles/show.html.erb
+++ b/tests/test_app/app/views/profiles/show.html.erb
@@ -1,0 +1,3 @@
+<h2>User Public Profile</h2>
+
+<p>User Name: <%= @profile.username %></p>

--- a/tests/test_app/config/routes.rb
+++ b/tests/test_app/config/routes.rb
@@ -1,3 +1,4 @@
 TestApp::Application.routes.draw do
   resources :articles, :posts, :widgets, :dummy
+  get 'profiles/[:id]' => 'profiles#show'
 end

--- a/tests/test_app/db/migrate/20150207135825_create_profiles.rb
+++ b/tests/test_app/db/migrate/20150207135825_create_profiles.rb
@@ -1,0 +1,10 @@
+class CreateProfiles < ActiveRecord::Migration
+  def change
+    create_table :profiles do |t|
+      t.string :username
+      t.string :slug
+
+      t.timestamps
+    end
+  end
+end

--- a/tests/test_app/db/migrate/20150207140310_create_friendly_id_slugs.rb
+++ b/tests/test_app/db/migrate/20150207140310_create_friendly_id_slugs.rb
@@ -1,0 +1,18 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration
+
+  def self.up
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 40
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], :unique => true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+
+  def self.down
+    drop_table :friendly_id_slugs
+  end
+end

--- a/tests/test_app/db/schema.rb
+++ b/tests/test_app/db/schema.rb
@@ -11,13 +11,24 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130719024021) do
+ActiveRecord::Schema.define(:version => 20150207140310) do
 
   create_table "articles", :force => true do |t|
     t.string   "name"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
   end
+
+  create_table "friendly_id_slugs", :force => true do |t|
+    t.string   "slug",                         :null => false
+    t.integer  "sluggable_id",                 :null => false
+    t.string   "sluggable_type", :limit => 40
+    t.datetime "created_at"
+  end
+
+  add_index "friendly_id_slugs", ["slug", "sluggable_type"], :name => "index_friendly_id_slugs_on_slug_and_sluggable_type", :unique => true
+  add_index "friendly_id_slugs", ["sluggable_id"], :name => "index_friendly_id_slugs_on_sluggable_id"
+  add_index "friendly_id_slugs", ["sluggable_type"], :name => "index_friendly_id_slugs_on_sluggable_type"
 
   create_table "impressions", :force => true do |t|
     t.string   "impressionable_type"
@@ -46,6 +57,13 @@ ActiveRecord::Schema.define(:version => 20130719024021) do
 
   create_table "posts", :force => true do |t|
     t.string   "name"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  create_table "profiles", :force => true do |t|
+    t.string   "username"
+    t.string   "slug"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
   end

--- a/tests/test_app/spec/controllers/impressionist_uniqueness_spec.rb
+++ b/tests/test_app/spec/controllers/impressionist_uniqueness_spec.rb
@@ -306,6 +306,22 @@ describe DummyController do
 
   end
 
+  describe 'impressionist with friendly id' do
+    it 'should unique' do
+      impressionable = Profile.find 1
+      # get 'profiles/test_profile'
+      # get 'profiles/test_profile'
+      controller.stub(:controller_name).and_return('profile')
+      controller.stub(:action_name).and_return('show')
+      controller.stub(:params).and_return({id: 'test_profile'})
+      controller.request.stub(:remote_ip).and_return('1.2.3.4')
+
+      controller.impressionist(impressionable, nil, :unique => [:impressionable_type, :impressionable_id])
+      controller.impressionist(impressionable, nil, :unique => [:impressionable_type, :impressionable_id])
+      Impression.should have(@impression_count + 1).records
+    end
+  end
+
   shared_examples_for 'an impressionable action' do
     it 'should record an impression' do
       controller.impressionist_subapp_filter(condition)

--- a/tests/test_app/spec/controllers/impressionist_uniqueness_spec.rb
+++ b/tests/test_app/spec/controllers/impressionist_uniqueness_spec.rb
@@ -308,12 +308,11 @@ describe DummyController do
 
   describe 'impressionist with friendly id' do
     it 'should unique' do
-      impressionable = Profile.find 1
-      # get 'profiles/test_profile'
-      # get 'profiles/test_profile'
+      impressionable = Profile.create({username: 'test_profile', slug: 'test_profile'})
+
       controller.stub(:controller_name).and_return('profile')
       controller.stub(:action_name).and_return('show')
-      controller.stub(:params).and_return({id: 'test_profile'})
+      controller.stub(:params).and_return({id: impressionable.slug})
       controller.request.stub(:remote_ip).and_return('1.2.3.4')
 
       controller.impressionist(impressionable, nil, :unique => [:impressionable_type, :impressionable_id])

--- a/tests/test_app/spec/fixtures/profiles.yml
+++ b/tests/test_app/spec/fixtures/profiles.yml
@@ -1,0 +1,4 @@
+one:
+  id: 1
+  username: test_profile
+  slug: test_profile

--- a/tests/test_app/spec/models/model_spec.rb
+++ b/tests/test_app/spec/models/model_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Impression do
-  fixtures :articles,:impressions,:posts
+  fixtures :articles,:impressions,:posts,:profiles
 
   before(:each) do
     @article = Article.find(1)

--- a/tests/test_app/spec/rails_generators/rails_generators_spec.rb
+++ b/tests/test_app/spec/rails_generators/rails_generators_spec.rb
@@ -4,7 +4,7 @@ require 'systemu'
 # FIXME this test might break the others if run before them
 # started fixing @nbit001
 describe Impressionist, :migration do
-  fixtures :articles,:impressions,:posts
+  fixtures :articles,:impressions,:posts,:profiles
   it "should delete existing migration and generate the migration file" do
     pending
     migrations_dir = "#{Rails.root}/db/migrate"


### PR DESCRIPTION
Fix unique impressionist of that instance which are using friendly_id. When any model use friendly_id, it send params[:id] = slug. But, in impressionist_controller > direct_create_statement method :impressionable_id checked with params[:id]. I am changed it by instance id.
I create profile model and add friendly_id. And add test code in test_app/spec/controllers/impressionist_uniqueness_spec.rb for testing this issue.