### PR TITLE
Fix performance deleting

### DIFF
--- a/lib/impressionist/is_impressionable.rb
+++ b/lib/impressionist/is_impressionable.rb
@@ -15,7 +15,7 @@ module Impressionist
       def define_association
         has_many(:impressions,
         :as => :impressionable,
-        :dependent => :destroy)
+        :dependent => :delete_all)
       end
     end
   

--- a/lib/impressionist/models/mongo_mapper/impressionist/impressionable.rb
+++ b/lib/impressionist/models/mongo_mapper/impressionist/impressionable.rb
@@ -9,7 +9,7 @@ module Impressionist
         def is_impressionable(options={})
           many(:impressions,
           :as => :impressionable,
-          :dependent => :destroy)
+          :dependent => :delete_all)
 
           @impressionist_cache_options = options
         end

--- a/tests/test_app/spec/models/model_spec.rb
+++ b/tests/test_app/spec/models/model_spec.rb
@@ -57,7 +57,7 @@ describe Impression do
     @article.impressionist_count(:filter=>:session_hash).should eq 7
   end
 
-  # tests :dependent => :destroy
+  # tests :dependent => :delete_all
   it "should delete impressions on deletion of impressionable" do
     #impressions_count = Impression.all.size
     a = Article.create


### PR DESCRIPTION
Please change has_many dependent "destroy" to "delete_all".

So for example,

:destroy

``` sql
SELECT `impressions`.* FROM `impressions` WHERE `impressions`.`impressionable_id` = 1 AND `impressions`.`impressionable_type` = 'Article'
DELETE FROM `impressions` WHERE `impressions`.`id` = 1
DELETE FROM `impressions` WHERE `impressions`.`id` = 2
DELETE FROM `impressions` WHERE `impressions`.`id` = 3
...
```

:delete_all

``` sql
DELETE FROM `impressions` WHERE `impressions`.`impressionable_id` = 1 AND `impressions`.`impressionable_type` = 'Article'
```

Thanks.
