### PR TITLE
Remove httpclient due to deprecation warning for #timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 before_script:
   - cd tests/test_app
   - bundle exec rails g impressionist -f
-  - bundle exec rake db:migrate
+  - bundle exec rake db:create db:migrate RAILS_ENV=test
   - cd ..
 rvm:
   - 1.9.3

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -22,6 +22,9 @@ group :test do
   gem 'simplecov'
   gem 'systemu'
   gem 'friendly_id', '~> 4.0.9'
+
+  # test/unit has been removed by default in Ruby 2.2.x+
+  gem 'test-unit'
 end
 
 gemspec :path => '../'

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -22,6 +22,9 @@ group :test do
   gem 'simplecov'
   gem 'systemu'
   gem 'friendly_id', '~> 5.1.0'
+
+  # test/unit has been removed by default in Ruby 2.2.x+
+  gem 'test-unit'
 end
 
 gemspec :path => '../'

--- a/impressionist.gemspec
+++ b/impressionist.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |s|
   s.require_path  = 'lib'
   s.required_rubygems_version = Gem::Requirement.new('>= 1.3.6') if s.respond_to? :required_rubygems_version=
 
-  s.add_dependency 'httpclient', '~> 2.2'
   s.add_dependency 'nokogiri', '~> 1.6'
-
   s.add_development_dependency 'bundler', '~> 1.0'
 end

--- a/lib/impressionist/bots.rb
+++ b/lib/impressionist/bots.rb
@@ -1,18 +1,21 @@
-require 'httpclient'
+require 'timeout'
+require 'net/http'
 require 'nokogiri'
 
 module Impressionist
   module Bots
     LIST_URL = "http://www.user-agents.org/allagents.xml"
     def self.consume
-      response = HTTPClient.new.get_content(LIST_URL)
-      doc = Nokogiri::XML(response)
-      list = []
-      doc.xpath('//user-agent').each do |agent|
-        type = agent.xpath("Type").text
-        list << agent.xpath("String").text.gsub("&lt;","<") if ["R","S"].include?(type) #gsub hack for badly formatted data
+      Timeout.timeout(4) do
+        response = Net::HTTP.get(URI.parse(LIST_URL))
+        doc = Nokogiri::XML(response)
+        list = []
+        doc.xpath('//user-agent').each do |agent|
+          type = agent.xpath("Type").text
+          list << agent.xpath("String").text.gsub("&lt;","<") if ["R","S"].include?(type) #gsub hack for badly formatted data
+        end
+        list
       end
-      list
     end
   end
 end

--- a/tests/test_app/Gemfile
+++ b/tests/test_app/Gemfile
@@ -36,6 +36,9 @@ group :development, :test do
   gem 'autotest-notification'
   gem 'rspec-rails', '~> 2.14.0'
   gem 'spork'
+
+  # test/unit has been removed by default in Ruby 2.2.x+
+  gem 'test-unit'
 end
 
 group :test do


### PR DESCRIPTION
/.rvm/gems/ruby-2.3.0/gems/httpclient-2.7.0.1/lib/httpclient/session.rb:867:in `read_body_length': Object#timeout is deprecated, use Timeout.timeout instead.

The current suite was not adding functionality, so tests have not been written, but all specs do pass