### PR TITLE
Rails 5: wrong number of arguments (given 2, expected 0..1)

### DIFF
--- a/app/models/impressionist/impressionable.rb
+++ b/app/models/impressionist/impressionable.rb
@@ -41,7 +41,7 @@ module Impressionist
 
       # Count all distinct impressions unless the :all filter is provided.
       distinct = options[:filter] != :all
-      if Rails::VERSION::MAJOR == 4
+      if Rails::VERSION::MAJOR >= 4
         distinct ? imps.select(options[:filter]).distinct.count : imps.count
       else
         distinct ? imps.count(options[:filter], :distinct => true) : imps.count


### PR DESCRIPTION
Fix issue #212   