### PR TITLE
Fix blob length in create_index in the generated migration

### DIFF
--- a/lib/generators/active_record/templates/create_impressions_table.rb
+++ b/lib/generators/active_record/templates/create_impressions_table.rb
@@ -22,7 +22,7 @@ class CreateImpressionsTable < ActiveRecord::Migration
     add_index :impressions, [:controller_name,:action_name,:request_hash], :name => "controlleraction_request_index", :unique => false
     add_index :impressions, [:controller_name,:action_name,:ip_address], :name => "controlleraction_ip_index", :unique => false
     add_index :impressions, [:controller_name,:action_name,:session_hash], :name => "controlleraction_session_index", :unique => false
-    add_index :impressions, [:impressionable_type, :impressionable_id, :params], :name => "poly_params_request_index", :unique => false
+    add_index :impressions, [:impressionable_type, :impressionable_id, :params], :name => "poly_params_request_index", :unique => false, :length => {:params => 255 }
     add_index :impressions, :user_id
   end
 


### PR DESCRIPTION
Per issue #222 