### PR TITLE
Option for dependent: :destroy

### DIFF
--- a/lib/impressionist/is_impressionable.rb
+++ b/lib/impressionist/is_impressionable.rb
@@ -3,19 +3,22 @@ module Impressionist
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def is_impressionable(options={})
-        define_association
-        @impressionist_cache_options = options
 
+      def is_impressionable(options={})
+        @impressionist_cache_options = options
+        dependent_destroy = options.fetch(:dependent_destroy, true)
+
+        define_association(dependent_destroy)
         true
       end
 
       private
 
-      def define_association
-        has_many(:impressions,
-        :as => :impressionable,
-        :dependent => :destroy)
+      def define_association(dependent_destroy)
+        assoc_options = {:as => :impressionable, :dependent => :destroy}
+        assoc_options.delete(:dependent) if !dependent_destroy
+
+        has_many(:impressions, assoc_options)
       end
     end
   

--- a/tests/test_app/Rakefile
+++ b/tests/test_app/Rakefile
@@ -2,6 +2,13 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+module TempFixForRakeLastComment
+  def last_comment
+    last_description
+  end 
+end
+Rake::Application.send :include, TempFixForRakeLastComment
+
 require File.expand_path('../config/application', __FILE__)
 
 TestApp::Application.load_tasks

--- a/tests/test_app/app/models/post.rb
+++ b/tests/test_app/app/models/post.rb
@@ -1,3 +1,3 @@
 class Post < ActiveRecord::Base
-  is_impressionable
+  is_impressionable(dependent_destroy: false)
 end

--- a/tests/test_app/spec/models/model_spec.rb
+++ b/tests/test_app/spec/models/model_spec.rb
@@ -59,12 +59,20 @@ describe Impression do
 
   # tests :dependent => :destroy
   it "should delete impressions on deletion of impressionable" do
-    #impressions_count = Impression.all.size
     a = Article.create
     i = a.impressions.create
     a.destroy
     a.destroyed?.should be_true
     i.destroyed?.should be_true
+  end
+  
+  # tests :dependent => :destroy
+  it "should not delete impressions on deletion of impressionable with params" do
+    p = Post.create
+    i = p.impressions.create
+    p.destroy
+    p.destroyed?.should be_true
+    i.destroyed?.should_not be_true
   end
 
 end


### PR DESCRIPTION
Hello @johnmcaliley 

Thanks for providing a nice and simple gem for tracking impressions.  I was struggling to find something that wasn't over complicated - so I was happy to come across this. 

I did however need the ability to soft delete impressionable records, and if they were restored that the impressions also still be available.  I have added that ability in this PR.

I am fairly new to contributing to open source (and ruby) - so let me know if there is anything that I should be doing differently.  I wanted a better way to check the options within the `define_association` method, but haven't worked much with modules so I couldn't find a way to access an instance variable from within that method.  I might keep trying and push an update if I find a better way.

Thanks