### PR TITLE
Green builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ before_script:
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0
+  - 2.2.0
+  - 2.3.0
   - jruby-head
   - rbx
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ before_script:
   - bundle exec rails g impressionist -f
   - bundle exec rake db:create db:migrate RAILS_ENV=test
   - cd ..
+script:
+  - bundle exec rake
 rvm:
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler
 before_script:
   - cd tests/test_app
   - bundle exec rails g impressionist -f

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -14,6 +14,7 @@ platforms :ruby, :mswin, :mingw do
 end
 
 group :test do
+  gem 'public_suffix', '< 1.5.0'
   gem 'capybara', '>= 2.0.3'
   gem 'minitest'
   gem 'minitest-rails'

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rake', '>= 0.9'
+gem 'rake', '>= 0.9', '< 11.0'
 gem 'rdoc', '>= 2.4.2'
 
 platforms :jruby do

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -14,6 +14,7 @@ platforms :ruby, :mswin, :mingw do
 end
 
 group :test do
+  gem 'public_suffix', '< 1.5.0'
   gem 'capybara', '>= 2.0.3'
   gem 'minitest'
   gem 'minitest-rails'

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rake', '>= 0.9'
+gem 'rake', '>= 0.9', '< 11.0'
 gem 'rdoc', '>= 2.4.2'
 
 platforms :jruby do

--- a/impressionist.gemspec
+++ b/impressionist.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.require_path  = 'lib'
   s.required_rubygems_version = Gem::Requirement.new('>= 1.3.6') if s.respond_to? :required_rubygems_version=
 
-  s.add_dependency 'nokogiri', '~> 1.6'
+  s.add_dependency 'nokogiri', RUBY_VERSION < '2.1.0' ? '~> 1.6.0' : '~> 1'
   s.add_development_dependency 'bundler', '~> 1.0'
 end

--- a/tests/test_app/Gemfile
+++ b/tests/test_app/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 3.2'
+gem 'rake', '< 11.0'
 
 gem 'impressionist', :path => '../../'
 

--- a/tests/test_app/Gemfile
+++ b/tests/test_app/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 3.2'
 gem 'rake', '< 11.0'
+gem 'public_suffix', '< 1.5.0'
 
 gem 'impressionist', :path => '../../'
 


### PR DESCRIPTION
Makes the build pass on TravisCI. My main concern about this change is the lock of Nokogiri to version `1.6.x` but to support ruby 1.9.3 and 2.0 that is required.