### PR TITLE
Update CHANGELOG.rdoc

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,4 +1,4 @@
-== 1.6.0 (2016-09-16)
+== 1.6.0 (2017-05-24)
 * Documentation example for counter_cache (#239, @fwolfst)
 * Green Travis CI builds (#238, @jgrau)
 * Rails 5.1 support (#241, @msimonborg)


### PR DESCRIPTION
According to https://rubygems.org/gems/impressionist, 1.6.0 is released on May 24, 2017.