### PR TITLE
Add params filtering on new column.

### DIFF
--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -59,7 +59,7 @@ module ImpressionistController
         :session_hash => session_hash,
         :ip_address => request.remote_ip,
         :referrer => request.referer,
-        :params => params_hash
+        :params => params_hash.except(Rails.application.config.filter_parameters)
         )
     end
 

--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -51,6 +51,7 @@ module ImpressionistController
 
     # creates a statment hash that contains default values for creating an impression via an AR relation.
     def associative_create_statement(query_params={})
+      filter = ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters)
       query_params.reverse_merge!(
         :controller_name => controller_name,
         :action_name => action_name,
@@ -59,7 +60,7 @@ module ImpressionistController
         :session_hash => session_hash,
         :ip_address => request.remote_ip,
         :referrer => request.referer,
-        :params => params_hash.except(Rails.application.config.filter_parameters)
+        :params => filter.filter(params_hash)
         )
     end
 

--- a/tests/test_app/spec/controllers/articles_controller_spec.rb
+++ b/tests/test_app/spec/controllers/articles_controller_spec.rb
@@ -78,7 +78,7 @@ describe ArticlesController do
       Rails.application.config.filter_parameters = [:password]
     end
 
-    it "should FILTER params that are included in filtering {}" do
+    it "values should not be recorded" do
       get "index", password: "best-password-ever"
       Impression.last.params.should eq("password" => "[FILTERED]")
     end

--- a/tests/test_app/spec/controllers/articles_controller_spec.rb
+++ b/tests/test_app/spec/controllers/articles_controller_spec.rb
@@ -71,4 +71,20 @@ describe ArticlesController do
     Impression.last.session_hash.size.should eq 32
     Impression.last.referrer.should eq nil
   end
+
+  describe "when filtering params" do
+    before do
+      @_filtered_params = Rails.application.config.filter_parameters
+      Rails.application.config.filter_parameters = [:password]
+    end
+
+    it "should FILTER params that are included in filtering {}" do
+      get "index", password: "best-password-ever"
+      Impression.last.params.should eq("password" => "[FILTERED]")
+    end
+
+    after do
+      Rails.application.config.filter_parameters = @_filtered_params
+    end
+  end
 end


### PR DESCRIPTION
This is to maintain security of any params that are not supposed to be logged. As well as a way to exclude params that may bust the size of a text field.