### PR TITLE
Implemented patch that will add the Rails major version to the migration file

### DIFF
--- a/lib/generators/active_record/templates/create_impressions_table.rb
+++ b/lib/generators/active_record/templates/create_impressions_table.rb
@@ -1,4 +1,4 @@
-class CreateImpressionsTable < ActiveRecord::Migration
+class CreateImpressionsTable < ActiveRecord::Migration<%= Rails::VERSION::MAJOR >= 5 ? "[#{Rails.version.to_f}]" : "" %>
   def self.up
     create_table :impressions, :force => true do |t|
       t.string :impressionable_type


### PR DESCRIPTION
This is to fix the issue with Rails 5.1+ that requires a major version to be declared and appended to the migration file. Similar fixes were recently added to gems such as Devise and [Petergate](https://github.com/elorest/petergate/commit/16dbbf52c6f955c7d47e3514c7135f0dce24b0ee).

I added the pull request gem version to a 5.1 project I added Impressionist to and it worked properly, while the previous version threw an error when I attempted to run the migration.