### PR TITLE
Fix Mongoid dependent strategy

### DIFF
--- a/lib/impressionist/models/mongoid/impression.rb
+++ b/lib/impressionist/models/mongoid/impression.rb
@@ -6,7 +6,6 @@ class Impression
   include Mongoid::Timestamps
 
   include Impressionist::CounterCache
-  Impressionist::SetupAssociation.new(self).set
 
   field :impressionable_id, type: BSON::ObjectId
   field :impressionable_type
@@ -23,4 +22,5 @@ class Impression
 
   after_save :impressionable_counter_cache_updatable?
 
+  belongs_to :impressionable, polymorphic: true
 end

--- a/lib/impressionist/models/mongoid/impressionist/impressionable.rb
+++ b/lib/impressionist/models/mongoid/impressionist/impressionable.rb
@@ -1,26 +1,35 @@
 module Impressionist
   module Impressionable
+    extend ActiveSupport::Concern
 
-  # extends AS::Concern
-  include Impressionist::IsImpressionable
+    module InstanceMethods
+      # Overides impressionist_count in order to provide mongoid compability
+      def impressionist_count(options={})
 
-    # Overides impressionist_count in order to provide mongoid compability
-    def impressionist_count(options={})
+        # Uses these options as defaults unless overridden in options hash
+        options.reverse_merge!(:filter => :request_hash, :start_date => nil, :end_date => Time.now)
 
-      # Uses these options as defaults unless overridden in options hash
-      options.reverse_merge!(:filter => :request_hash, :start_date => nil, :end_date => Time.now)
-
-      # If a start_date is provided, finds impressions between then and the end_date.
-      # Otherwise returns all impressions
-      imps = options[:start_date].blank? ? impressions :
-        impressions.between(created_at: options[:start_date]..options[:end_date])
+        # If a start_date is provided, finds impressions between then and the end_date.
+        # Otherwise returns all impressions
+        imps = options[:start_date].blank? ? impressions :
+          impressions.between(created_at: options[:start_date]..options[:end_date])
 
 
-      # Count all distinct impressions unless the :all filter is provided
-      distinct = options[:filter] != :all
-      distinct ? imps.where(options[:filter].ne => nil).distinct(options[:filter]).count : imps.count
+        # Count all distinct impressions unless the :all filter is provided
+        distinct = options[:filter] != :all
+        distinct ? imps.where(options[:filter].ne => nil).distinct(options[:filter]).count : imps.count
+      end
     end
 
+    module ClassMethods
+      def is_impressionable(options={})
+        has_many :impressions, 
+                 as: :impressionable, 
+                 dependent: :delete
+
+        @impressionist_cache_options = options
+      end
+    end
   end
 end
 

--- a/lib/impressionist/models/mongoid/impressionist/impressionable.rb
+++ b/lib/impressionist/models/mongoid/impressionist/impressionable.rb
@@ -2,24 +2,22 @@ module Impressionist
   module Impressionable
     extend ActiveSupport::Concern
 
-    module InstanceMethods
-      # Overides impressionist_count in order to provide mongoid compability
-      def impressionist_count(options={})
+    # Overides impressionist_count in order to provide mongoid compability
+    def impressionist_count(options={})
 
-        # Uses these options as defaults unless overridden in options hash
-        options.reverse_merge!(:filter => :request_hash, :start_date => nil, :end_date => Time.now)
+      # Uses these options as defaults unless overridden in options hash
+      options.reverse_merge!(:filter => :request_hash, :start_date => nil, :end_date => Time.now)
 
-        # If a start_date is provided, finds impressions between then and the end_date.
-        # Otherwise returns all impressions
-        imps = options[:start_date].blank? ? impressions :
-          impressions.between(created_at: options[:start_date]..options[:end_date])
+      # If a start_date is provided, finds impressions between then and the end_date.
+      # Otherwise returns all impressions
+      imps = options[:start_date].blank? ? impressions :
+        impressions.between(created_at: options[:start_date]..options[:end_date])
 
 
-        # Count all distinct impressions unless the :all filter is provided
-        distinct = options[:filter] != :all
-        distinct ? imps.where(options[:filter].ne => nil).distinct(options[:filter]).count : imps.count
-      end
-    end
+      # Count all distinct impressions unless the :all filter is provided
+      distinct = options[:filter] != :all
+      distinct ? imps.where(options[:filter].ne => nil).distinct(options[:filter]).count : imps.count
+    end    
 
     module ClassMethods
       def is_impressionable(options={})
@@ -28,6 +26,8 @@ module Impressionist
                  dependent: :delete
 
         @impressionist_cache_options = options
+
+        true
       end
     end
   end


### PR DESCRIPTION
Again I ran againts some compability problems while using the gem with Mongoid. The first problem was the option `dependent: :delete_all` being passed to the model, which is wrong for Mongoid as stated in the [documentation](https://docs.mongodb.com/mongoid/master/tutorials/mongoid-relations/#dependent-behaviour)
The other is not quite a problem, just a minor refactoring, since the relation is being setup in the `Impressionist::Impressionable` module, there's no need to call `Impressionist::SetupAssociation#set` method.

As far as I tested in my application (locally and in production) there's no bigger problems in those changes.

Note: `dependent: :delete` does not triggers callbacks, I don't know if this can be a issue for some users.