### PR TITLE
Add a 'touch' option for updated_at fields when using counter caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ Any option you pass to unique, impressionist_count will use it as its filter to 
     is_impressionable :counter_cache => true, :column_name => :my_column_name, :unique => :request_hash
     is_impressionable :counter_cache => true, :column_name => :my_column_name, :unique => :all
 
+By default, when Impresssionist updates your model's countner cache column, the model's `updated_at` column won't be updated. If you'd like to update the `updated_at` field of your model whenever the counter cache is changed, set `:touch => true`:
+    
+    is_impressionable :counter_cache => true, :column_name => :my_column_name, :touch => true
 
 Adding column to model
 ----------------------

--- a/app/models/impressionist/impressionable.rb
+++ b/app/models/impressionist/impressionable.rb
@@ -8,7 +8,8 @@ module Impressionist
       DEFAULT_CACHE ||= {
         :counter_cache => false,
         :column_name => :impressions_count,
-        :unique => :all
+        :unique => :all,
+        :touch => false
       }
 
       def impressionist_counter_cache_options

--- a/lib/impressionist/update_counters.rb
+++ b/lib/impressionist/update_counters.rb
@@ -13,7 +13,7 @@ module Impressionist
 
     def update
       klass.
-      update_counters(id, column_name => result)
+      update_counters(id, column_name => result, touch: true)
     end
 
     private

--- a/lib/impressionist/update_counters.rb
+++ b/lib/impressionist/update_counters.rb
@@ -13,7 +13,7 @@ module Impressionist
 
     def update
       klass.
-      update_counters(id, column_name => result, touch: true)
+      update_counters(id, column_name => result, touch: touch?)
     end
 
     private
@@ -61,6 +61,10 @@ module Impressionist
 
     def column_name
       cache_options[:column_name].to_s
+    end
+
+    def touch?
+      cache_options[:touch]
     end
 
     def cache_options


### PR DESCRIPTION
While it shouldn't be the default behavior, it's still useful to have the option to set the updated_at timestamp when updating an Impressionist counter cache.

Related issue: https://github.com/charlotte-ruby/impressionist/issues/162