### PR TITLE
remove deprecated use of ActionDispatch::Http::ParameterFilter

### DIFF
--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -51,7 +51,7 @@ module ImpressionistController
 
     # creates a statment hash that contains default values for creating an impression via an AR relation.
     def associative_create_statement(query_params={})
-      filter = ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters)
+      filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
       query_params.reverse_merge!(
         :controller_name => controller_name,
         :action_name => action_name,


### PR DESCRIPTION
`ActionDispatch::Http::ParameterFilter` will be removed from Rails 6.1. It's been replaced by `ActiveSupport::ParameterFilter`.