### PR TITLE
[Fix] Fix id null and bump version

### DIFF
--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -155,7 +155,7 @@ module ImpressionistController
       end
 
       unless id.is_a? String
-        id = id.cookie_value if Rack::Session::SessionId.const_defined?(:ID_VERSION) && Rack::Session::SessionId::ID_VERSION == 2
+        id = id.cookie_value if Rack::Session::SessionId.const_defined?(:ID_VERSION) && Rack::Session::SessionId::ID_VERSION == 2 && id
       end
 
       # id = cookies.session.id

--- a/lib/impressionist/version.rb
+++ b/lib/impressionist/version.rb
@@ -1,3 +1,3 @@
 module Impressionist
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
@johnmcaliley 
## Description
Related to #292, I made this PR for fix the crash error when `id` is null.
And I found that the master code different with my current gem file code. So, I bump the version of this gem for trigger bundle update.

Anw, I wish become maintainer for this repo. 🧀 