### PR TITLE
fix getting null id for some versions of rack

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - "spec/dummy/**/*"
+    - "impressionist.gemspec"
 
 inherit_from: .rubocop_todo.yml
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task default: :spec
 Bundler::GemHelper.install_tasks
 
 namespace :impressionist do
-  require File.dirname(__FILE__) + "/lib/impressionist/bots"
+  require "#{File.dirname(__FILE__)}/lib/impressionist/bots"
 
   desc "output the list of bots from http://www.user-agents.org/"
   task :bots do

--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -154,8 +154,8 @@ module ImpressionistController
         id = request.session_options[:id]
       end
 
-      unless id.is_a? String
-        id = id.cookie_value if Rack::Session::SessionId.const_defined?(:ID_VERSION) && Rack::Session::SessionId::ID_VERSION == 2
+      unless id.is_a?(String) && Rack::Session::SessionId.const_defined?(:ID_VERSION) && Rack::Session::SessionId::ID_VERSION == 2
+        id = id.cookie_value
       end
 
       # id = cookies.session.id

--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -149,7 +149,7 @@ module ImpressionistController
       # # request.session_options[:id].encode("ISO-8859-1")
       if Rails::VERSION::MAJOR >= 4
         session["init"] = true
-        id = session.id.to_s
+        id = session.id.public_id.to_s
       else
         id = request.session_options[:id]
       end

--- a/lib/impressionist/engine.rb
+++ b/lib/impressionist/engine.rb
@@ -9,7 +9,7 @@ module Impressionist
 
 
   initializer 'impressionist.controller' do
-    require "impressionist/controllers/mongoid/impressionist_controller.rb" if orm == :mongoid.to_s
+    require "impressionist/controllers/mongoid/impressionist_controller" if orm == :mongoid.to_s
 
     ActiveSupport.on_load(:action_controller) do
      include ImpressionistController::InstanceMethods

--- a/lib/impressionist/version.rb
+++ b/lib/impressionist/version.rb
@@ -1,3 +1,3 @@
 module Impressionist
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/spec/setup_association_spec.rb
+++ b/spec/setup_association_spec.rb
@@ -9,14 +9,14 @@ describe Impressionist::SetupAssociation do
   let(:setup_association) { described_class.new(mock) }
 
   it 'will include when togglable' do
-    expect(mock).to receive(:attr_accessible).with(any_args).and_return(true)
-    expect(setup_association).to receive(:toggle).and_return(true)
+    allow(mock).to receive(:attr_accessible).with(any_args).and_return(true)
+    allow(setup_association).to receive(:toggle).and_return(true)
 
     expect(setup_association).to be_include_attr_acc
   end
 
   it 'will not include if it is not togglable' do
-    expect(setup_association).to receive(:toggle).and_return(false)
+    allow(setup_association).to receive(:toggle).and_return(false)
     expect(setup_association).not_to be_include_attr_acc
   end
 


### PR DESCRIPTION
Users with rake version that do not have https://github.com/rack/rack/pull/1462 will have problem getting `session.id.to_s` after https://github.com/rack/rack/security/advisories/GHSA-hrqr-hxpp-chr3

I'd say having `public_id` is much safer, it should not break any version.

I also bumped into this issue https://github.com/charlotte-ruby/impressionist/issues/292 which might be fixed with this change.