### PR TITLE
Better nil guards from calling cookie value on nil or string

### DIFF
--- a/app/controllers/impressionist_controller.rb
+++ b/app/controllers/impressionist_controller.rb
@@ -154,7 +154,7 @@ module ImpressionistController
         id = request.session_options[:id]
       end
 
-      unless id.is_a? String
+      if id.respond_to?(:cookie_value)
         id = id.cookie_value if Rack::Session::SessionId.const_defined?(:ID_VERSION) && Rack::Session::SessionId::ID_VERSION == 2
       end
 


### PR DESCRIPTION
[Fixes #292]