### PR TITLE
Publish Gem Releases via GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
-name: Main
+name: main
 on: [push]
 jobs:
-  Build-And-Run-Tests:
+  build-and-run-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: release
+on:
+  push:
+    branches: [master]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      RUBY_VERSION: 3.0.3
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        id: release
+        with:
+          release-type: ruby
+          package-name: impressionist
+          bump-minor-pre-major: true
+          version-file: "lib/impressionist/version.rb"
+      - uses: actions/checkout@v2
+        if: ${{ steps.release.outputs.release_created }}
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+        if: ${{ steps.release.outputs.release_created }}
+      - run: bundle
+        if: $${{ steps.release.outputs.release_created }}
+      - name: publish gem
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+           GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+        if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Inspired by [this](https://andrewm.codes/blog/automating-ruby-gem-releases-with-github-actions/) blog post, I thought it would be nice to have automated publishing of this gem via GitHub actions.

This uses the [Release Please](https://github.com/google-github-actions/release-please-action) action to automate version setting and publishing a release to rubygems.

# Help Needed

- [ ] Update `RUBYGEMS_AUTH_TOKEN` value in [secrets section](https://github.com/charlotte-ruby/impressionist/settings/secrets/actions)
