### PR TITLE
 Fixed undefined error when running rails g impressionist(undefined method `timestamped_migrations')

### DIFF
--- a/lib/generators/active_record/impressionist_generator.rb
+++ b/lib/generators/active_record/impressionist_generator.rb
@@ -7,7 +7,7 @@ module ActiveRecord
       # FIX, why is this implementing rails behaviour?
       def self.next_migration_number(dirname)
         sleep 1
-        if ActiveRecord::Base.timestamped_migrations
+        if timestamped_migrations?
           Time.now.utc.strftime("%Y%m%d%H%M%S")
         else
           "%.3d" % (current_migration_number(dirname) + 1)
@@ -16,6 +16,18 @@ module ActiveRecord
 
       def create_migration_file
         migration_template 'create_impressions_table.rb.erb', 'db/migrate/create_impressions_table.rb'
+      end
+
+      class << self
+        private
+
+        def timestamped_migrations?
+          if Rails::VERSION::MAJOR >= 7
+            ActiveRecord.timestamped_migrations
+          else
+            ActiveRecord::Base.timestamped_migrations
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
The following error occurred when running rails g impressionist, so I fixed it.

```
/usr/local/bundle/gems/activerecord-7.1.3.2/lib/active_record/dynamic_matchers.rb:22:in `method_missing': undefined method `timestamped_migrations' for ActiveRecord::Base:Class (NoMethodError)
```

ActiveRecord.timestamped_migrations is now used when the major version of rails is 7 or higher.