### PR TITLE
Replace Code Climate Badge with Qlty one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![Impressionist Logo](https://github.com/charlotte-ruby/impressionist/raw/master/logo.png)
 
 [![Main](https://github.com/charlotte-ruby/impressionist/actions/workflows/main.yml/badge.svg)](https://github.com/charlotte-ruby/impressionist/actions/workflows/main.yml)
-[![Code Climate](https://codeclimate.com/github/charlotte-ruby/impressionist.png)](https://codeclimate.com/github/charlotte-ruby/impressionist)
 
 WE ARE LOOKING FOR MAINTAINERS.  CONTACT @johnmcaliley IF YOU ARE INTERESTED IN HELPING
 =======================================================================================

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Impressionist Logo](https://github.com/charlotte-ruby/impressionist/raw/master/logo.png)
 
 [![Main](https://github.com/charlotte-ruby/impressionist/actions/workflows/main.yml/badge.svg)](https://github.com/charlotte-ruby/impressionist/actions/workflows/main.yml)
+[![Maintainability](https://qlty.sh/gh/charlotte-ruby/projects/impressionist/maintainability.svg)](https://qlty.sh/gh/charlotte-ruby/projects/impressionist)
 
 WE ARE LOOKING FOR MAINTAINERS.  CONTACT @johnmcaliley IF YOU ARE INTERESTED IN HELPING
 =======================================================================================


### PR DESCRIPTION
It does not look like CodeClimate is a free thing anymore. [Qlty](https://qlty.sh/gh/charlotte-ruby/projects/impressionist) has taken it's place

<img width="1608" height="1216" alt="Screenshot 2026-02-08 at 4 57 59 PM" src="https://github.com/user-attachments/assets/d3085e9c-6ce7-4bd8-b386-7620206067d2" />

We'll likely have to configure SimpleCov to get code coverage metrics. I only updated the README to use the maintainability badge for now